### PR TITLE
Abort decoding on a leading zero in a tag.

### DIFF
--- a/src/ber_der.ml
+++ b/src/ber_der.ml
@@ -136,14 +136,16 @@ module R = struct
 
 
   let p_big_tag buf =
+    let byte_at = get_uint8 buf in
     let rec loop acc i =
-      let byte = get_uint8 buf i in
+      let byte = byte_at i in
       let acc' = (acc lsl 7) + (byte land 0x7f) in
       match byte land 0x80 with
       | _ when acc' < acc -> parse_error "tag overflow"
       | 0                 -> (acc', succ i)
       | _                 -> loop acc' (succ i) in
-    loop 0 1
+    if (byte_at 1) land 0x7f == 0 then parse_error "leading zero"
+    else loop 0 1
 
   let p_big_length buf off n =
     let last = off + n - 1 in

--- a/tests/testlib.ml
+++ b/tests/testlib.ml
@@ -563,6 +563,11 @@ let anticases = [
     ]
   ] ;
 
+  anticase "leading zero" Asn.(implicit 127 bool) [
+    [ 0x9f; 0x80; 0x7F; 0x01; 0xff]
+  ];
+
+
   anticase "length overflow" Asn.bool [
     [ 0x01;
       0x88;


### PR DESCRIPTION
Thou shalt ISO/IEC 8825-1:2008 8.1.2.4.2 c):

>   "bits 7 to 1 of the first subsequent octet shall not all be zero."
