### PR TITLE
Fix random_time_tests on 32-bit platforms

### DIFF
--- a/tests/testlib.ml
+++ b/tests/testlib.ml
@@ -103,10 +103,14 @@ let test_no_decode encoding (ATC (_, asn, examples)) _ =
 (* Prim tests *)
 
 let random_time_tests ~n _ = (* round trip with result of Unix.gmtime  *)
-  let about_200_years = Int64.(mul 200L (mul 365L 86_400L)) in
+  let time_span = if Sys.word_size == 32
+                    then 4294967295L (* maximal 32-Bit value, so the test doesn't break *)
+                    else 6307200000L (* about 200 Years *)
+  in
+
   let rtime span = Int64.(sub (Random.int64 (succ span)) (div span 2L)) in
   let test () =
-    let ti = rtime about_200_years (* around the unix epoch *) in
+    let ti = rtime time_span (* around the unix epoch *) in
     let t  = Int64.to_float ti in
     let tm = Unix.gmtime t in
     let t' = Asn.Time.date_to_posix_time


### PR DESCRIPTION
This resolves #13.