### PR TITLE
support for enumerations (simple type 0x0A)

### DIFF
--- a/src/asn.mli
+++ b/src/asn.mli
@@ -287,6 +287,11 @@ module S : sig
   val oid : oid t
   (** [oid] is ASN.1 [OBJECT IDENTIFIER]. *)
 
+  val enumerated : (int * 'a) list -> 'a t
+  (** [enumerated xs] is ASN.1 [ENUMERATED], truncated to an int
+
+      [xs] is a list of [(int, x)], where [int] denotes the mapping to [x]. *)
+
   val generalized_time : Ptime.t t
   (** [generalized_time] is ASN.1 [GeneralizedTime]. *)
 

--- a/src/asn_ber_der.ml
+++ b/src/asn_ber_der.ml
@@ -173,6 +173,7 @@ module R = struct
       | Octets     -> string_like tag (module Prim.Octets)
       | Null       -> primitive tag Prim.Null.of_cstruct
       | OID        -> primitive tag Prim.OID.of_cstruct
+      | Enumerated -> primitive tag Prim.Integer.of_cstruct
       | CharString -> string_like tag (module Prim.Gen_string)
 
   let peek asn =
@@ -444,6 +445,7 @@ module W = struct
     | Octets     -> encode_s a (module Prim.Octets)
     | Null       -> encode @@ Prim.Null.to_writer a
     | OID        -> encode @@ Prim.OID.to_writer a
+    | Enumerated -> encode @@ Prim.Integer.to_writer a
     | CharString -> encode @@ Prim.Gen_string.to_writer a
 
 

--- a/src/asn_core.ml
+++ b/src/asn_core.ml
@@ -134,6 +134,7 @@ and _ prim =
   | Octets     : Cstruct.t prim
   | Null       : unit      prim
   | OID        : OID.t     prim
+  | Enumerated : Z.t       prim
   | CharString : string    prim
 
 
@@ -150,6 +151,7 @@ let tag_of_p : type a. a prim -> tag =
   | Octets     -> Universal 0x04
   | Null       -> Universal 0x05
   | OID        -> Universal 0x06
+  | Enumerated -> Universal 0x0a
   | CharString -> Universal 0x1d
 
 


### PR DESCRIPTION
documentation is e.g. [here](https://www.obj-sys.com/asn1tutorial/node10.html) -- an enumerate is just an integer which maps to sth high level.

I took the liberty to cap enumerated at `int` size, instead of full `Z.t` range - this is much more convenient for writing (but wrong according to the standard, feel free to complain about it).

the reason I want to have enumerate is RFC5280 again (CRL, there in the revocation list a `CRLReason extension` may be present):
```
id-ce-cRLReasons OBJECT IDENTIFIER ::= { id-ce 21 }

CRLReason ::= ENUMERATED {
     unspecified             (0),
     keyCompromise           (1),
     cACompromise            (2),
     affiliationChanged      (3),
     superseded              (4),
     cessationOfOperation    (5),
     certificateHold         (6),
     removeFromCRL           (8),
     privilegeWithdrawn      (9),
     aACompromise           (10) }
```