### PR TITLE
Use bigarray-compat

### DIFF
--- a/asn1-combinators.opam
+++ b/asn1-combinators.opam
@@ -15,6 +15,7 @@ depends: [
   "dune" {build}
   "cstruct" {>= "1.6.0"}
   "zarith"
+  "bigarray-compat"
   "ptime"
   "alcotest" {with-test}
 ]

--- a/src/asn_prim.ml
+++ b/src/asn_prim.ml
@@ -4,6 +4,7 @@
 open Asn_core
 
 module Writer = Asn_writer
+module Bigarray = Bigarray_compat
 
 module type Prim = sig
   type t

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
   (name asn1_combinators)
   (public_name asn1-combinators)
   (synopsis "Embed typed ASN.1 grammars in OCaml")
-  (libraries cstruct zarith ptime)
+  (libraries cstruct zarith bigarray-compat ptime)
   (wrapped false)
   (private_modules asn_oid asn_cache asn_writer asn_prim asn_core asn_random
                    asn_combinators asn_ber_der))


### PR DESCRIPTION
In the mirage dunification effort (mirage/mirage#969)

The goal of `bigarray-compat` is to use `Stdlib.Bigarray` when possible (>= 4.07) but fallback to `Bigarray`. This allows to avoid the `unix` dependency grabbed by `Bigarray` and helps for mirage builds. 

It's also possible to directly use `Stdlib.Bigarray` instead, if `< 4.07` compatibility is not necessary.