### PR TITLE
Fully apply Cstruct.to_string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## v0.2.3 (2020-09-28)
+* adapt to cstruct 6.0.0 API changes (#34 by @dinosaure)
+
 ## v0.2.2 (2020-01-29)
 * packaging improvements: add lower bound to dune dependency, improve test
   invocation, remove version from dune-project

--- a/src/asn_prim.ml
+++ b/src/asn_prim.ml
@@ -146,7 +146,7 @@ module Gen_string : Prim_s with type t = string = struct
 
   type t = string
 
-  let of_cstruct = Cstruct.to_string
+  let of_cstruct x = Cstruct.to_string x
 
   let to_writer = Writer.of_string
 


### PR DESCRIPTION
`Cstruct.to_string` requiert `?off` and `?len` argument now.