### PR TITLE
Add support for OCaml 4.12

### DIFF
--- a/src/asn_ber_der.ml
+++ b/src/asn_ber_der.ml
@@ -402,9 +402,9 @@ module W = struct
           let fn = { Seq.f = fun a asn xs ->
             ( Asn_core.tag a asn, encode conf None a asn ) :: xs } in
           Writer.concat @@
-            List.( map snd @@
-              sort (fun (t1, _) (t2, _) -> compare t1 t2) @@
-                Seq.fold_with_value fn [] a asns )
+            List.map snd @@
+              List.sort (fun (t1, _) (t2, _) -> compare t1 t2) @@
+                Seq.fold_with_value fn [] a asns
         in
         e_constructed (tag @? set_tag) @@
           if conf.der then h_sorted conf a asns else e_seq conf a asns

--- a/src/asn_prim.ml
+++ b/src/asn_prim.ml
@@ -33,7 +33,7 @@ let random_size = function
   | Some size -> size
   | None      -> Random.int 20
 
-let random_string ?size ~chars:(lo, hi) =
+let random_string ?size ~chars:(lo, hi) () =
   String.init (random_size size)
     (fun _ -> Char.chr (random_int_r lo hi))
 
@@ -151,7 +151,7 @@ module Gen_string : Prim_s with type t = string = struct
   let to_writer = Writer.of_string
 
   let random ?size () =
-    random_string ?size ~chars:(32, 127)
+    random_string ?size ~chars:(32, 127) ()
 
   let (concat, length) = String.(concat "", length)
 end
@@ -167,7 +167,7 @@ module Octets : Prim_s with type t = Cstruct.t = struct
   let to_writer = Writer.of_cstruct
 
   let random ?size () =
-    random_string ?size ~chars:(0, 256) |> Cstruct.of_string
+    random_string ?size ~chars:(0, 256) () |> Cstruct.of_string
 
   let concat = Cstruct.concat
 

--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,6 @@
   (synopsis "Embed typed ASN.1 grammars in OCaml")
   (libraries cstruct zarith bigarray-compat ptime stdlib-shims)
   (wrapped false)
-  (flags :standard -w -16)
   (private_modules asn_oid asn_cache asn_writer asn_prim asn_core asn_random
                    asn_combinators asn_ber_der))
 

--- a/src/dune
+++ b/src/dune
@@ -4,6 +4,7 @@
   (synopsis "Embed typed ASN.1 grammars in OCaml")
   (libraries cstruct zarith bigarray-compat ptime stdlib-shims)
   (wrapped false)
+  (flags :standard -w -16)
   (private_modules asn_oid asn_cache asn_writer asn_prim asn_core asn_random
                    asn_combinators asn_ber_der))
 


### PR DESCRIPTION
* `List.( ... )` opens the `List` module. However in OCaml 4.12 `List.compare` was added and now shadows `Stdlib.compare` in this particular context.

* `-w -16` is here to silence the following warning/error:
```
$ dune build
File "src/asn_prim.ml", line 36, characters 19-23:
36 | let random_string ?size ~chars:(lo, hi) =
                        ^^^^
Error (warning 16 [unerasable-optional-argument]): this optional argument cannot be erased.
```