### PR TITLE
fix length overflow (32 bit)

### DIFF
--- a/src/asn_prim.ml
+++ b/src/asn_prim.ml
@@ -54,7 +54,7 @@ module Int64 = struct
   let max_p_int = Int64.of_int Stdlib.max_int
 
   let to_nat_checked i64 =
-    if i64 < 0L || i64 > max_int then None else Some (to_int i64)
+    if i64 < 0L || i64 > max_p_int then None else Some (to_int i64)
 
 end
 

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -369,7 +369,11 @@ let anticases = [
   [ "0300"; "030101"; "030208ff" ];
 
   case "null with indefinite length" Asn.S.null
-  [ "0580"; "058000"; "05800000" ]
+  [ "0580"; "058000"; "05800000" ];
+
+  case "32 bit length overflow"
+  Asn.S.(sequence2 (required integer) (required integer))
+  [ "30850100000006020180020180" ];
 ]
 
 let der_anticases = [


### PR DESCRIPTION
This is a negative test case supposed to fail (so the decoding is successful, while it should fail) on 32 bit (due to an error in Asn_prim.Int64). Once the OCaml-CI confirmed the failure, I'll push another commit to fix it.

EDIT: CI confirmed failure, fix pushed.