### PR TITLE
use Cstruct.length instead of deprecated Cstruct.len

### DIFF
--- a/asn1-combinators.opam
+++ b/asn1-combinators.opam
@@ -11,12 +11,10 @@ build: [ ["dune" "subst"] {pinned}
          ["dune" "build" "-p" name "-j" jobs ]
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 depends: [
-  "ocaml" {>="4.05.0"}
+  "ocaml" {>="4.08.0"}
   "dune" {>= "1.2.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "6.0.0"}
   "zarith"
-  "bigarray-compat"
-  "stdlib-shims"
   "ptime"
   "alcotest" {with-test}
 ]

--- a/src/asn_ber_der.ml
+++ b/src/asn_ber_der.ml
@@ -123,7 +123,7 @@ module R = struct
 
     let split_off cs off n =
       let k = off + n in
-      Cstruct.(sub cs off n, sub cs k (len cs - k))
+      Cstruct.(sub cs off n, sub cs k (length cs - k))
 
     let rec children cfg eof acc cs =
       if eof cs then (List.rev acc, cs) else

--- a/src/asn_combinators.ml
+++ b/src/asn_combinators.ml
@@ -12,8 +12,8 @@ end
 
 let clone_cs cs =
   let open Cstruct in
-  let ds = create_unsafe (len cs) in
-  blit cs 0 ds 0 (len cs); cs
+  let ds = create_unsafe (length cs) in
+  blit cs 0 ds 0 (length cs); cs
 
 type cls = [ `Universal | `Application | `Private ]
 
@@ -76,7 +76,7 @@ and bit_string_cs =
   let f = function
   | 0, cs -> cs
   | clip, cs ->
-      let n = Cstruct.len cs in
+      let n = Cstruct.length cs in
       let last = Cstruct.get_uint8 cs (n - 1) in
       let cs = clone_cs cs
       and last = last land (lnot (1 lsl clip - 1)) in

--- a/src/asn_prim.ml
+++ b/src/asn_prim.ml
@@ -4,7 +4,6 @@
 open Asn_core
 
 module Writer = Asn_writer
-module Bigarray = Bigarray_compat
 
 module type Prim = sig
   type t
@@ -171,7 +170,7 @@ module Octets : Prim_s with type t = Cstruct.t = struct
 
   let concat = Cstruct.concat
 
-  let length = Cstruct.len
+  let length = Cstruct.length
 
 end
 
@@ -188,21 +187,21 @@ struct
   type t = int * Cstruct.t
 
   let of_cstruct cs =
-    let n = Cstruct.len cs in
+    let n = Cstruct.length cs in
     if n = 0 then parse_error "BITS" else
     let unused = Cstruct.get_uint8 cs 0 in
     if n = 1 && unused > 0 || unused > 7 then parse_error "BITS" else
     unused, Octets.of_cstruct (Cstruct.shift cs 1)
 
   let to_writer (unused, cs) =
-    let size = Cstruct.len cs in
+    let size = Cstruct.length cs in
     let write off cs' =
       Cstruct.set_uint8 cs' off unused;
       Cstruct.blit cs 0 cs' (off + 1) size in
     Writer.immediate (size + 1) write
 
   let to_array (unused, cs) =
-    Array.init (Cstruct.len cs * 8 - unused) @@ fun i ->
+    Array.init (Cstruct.length cs * 8 - unused) @@ fun i ->
       let byte = (Cstruct.get_uint8 cs (i / 8)) lsl (i mod 8) in
       byte land 0x80 = 0x80
 
@@ -237,7 +236,7 @@ struct
       go css in
     (unused, Cstruct.concat css')
 
-  and length (unused, cs) = Cstruct.len cs - unused
+  and length (unused, cs) = Cstruct.length cs - unused
 
 end
 
@@ -268,7 +267,7 @@ module OID = struct
       0 -> []
     | n -> let (c, i') = int_chain cs i n in
            c :: components cs i' (n + i - i') in
-    match Cstruct.len cs with
+    match Cstruct.length cs with
       0 -> parse_error "OID: 0 length"
     | n ->
         let (b1, i) = int_chain cs 0 n in

--- a/src/asn_writer.ml
+++ b/src/asn_writer.ml
@@ -2,7 +2,7 @@
    See LICENSE.md. *)
 
 let cs_lex_compare cs1 cs2 =
-  let (s1, s2) = Cstruct.(len cs1, len cs2) in
+  let (s1, s2) = Cstruct.(length cs1, length cs2) in
   let rec go i lim =
     if i = lim then
       compare s1 s2
@@ -42,7 +42,7 @@ let of_string str =
   (n, fun off cs -> Cstruct.blit_from_string str 0 cs off n)
 
 let of_cstruct cs' =
-  let n = Cstruct.len cs' in
+  let n = Cstruct.length cs' in
   (n, fun off cs -> Cstruct.blit cs' 0 cs off n)
 
 let of_byte b = (1, fun off cs -> Cstruct.set_uint8 cs off b)

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
   (name asn1_combinators)
   (public_name asn1-combinators)
   (synopsis "Embed typed ASN.1 grammars in OCaml")
-  (libraries cstruct zarith bigarray-compat ptime stdlib-shims)
+  (libraries cstruct zarith ptime)
   (wrapped false)
   (private_modules asn_oid asn_cache asn_writer asn_prim asn_core asn_random
                    asn_combinators asn_ber_der))

--- a/tests/bench.ml
+++ b/tests/bench.ml
@@ -21,7 +21,7 @@ let mmap fd = Bigarray.(
 let bench_certs filename =
   let cs = mmap Unix.(openfile filename [O_RDONLY] 0) in
   let rec bench n cs =
-    if Cstruct.len cs = 0 then n else
+    if Cstruct.length cs = 0 then n else
       match Asn.decode X509.cert_ber cs with
       | Ok (_, cs) -> bench (succ n) cs
       | Error e -> invalid_arg (Format.asprintf "%a" Asn.pp_error e) in

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -3,7 +3,7 @@
 
 let pp_hex_cs ppf =
   let pp ppf cs =
-    for i = 0 to Cstruct.len cs - 1 do
+    for i = 0 to Cstruct.length cs - 1 do
       Format.fprintf ppf "%02x@ " (Cstruct.get_uint8 cs i)
     done in
   Format.fprintf ppf "@[%a@]" pp


### PR DESCRIPTION
requires cstruct 6.0.0

also require OCaml 4.07.0 to drop bigarray-compat and stdlib-shims dependencies