### PR TITLE
Provide Asn.S.unsigned_integer, which includes transformations to unsigned int

### DIFF
--- a/src/asn.mli
+++ b/src/asn.mli
@@ -276,7 +276,8 @@ module S : sig
   (** [integer] is ASN.1 [INTEGER]. The representation is a [string]. Be aware
       these are two's complement signed integers, in order to encode a positive
       number where the first bit is set (i.e. 128 = [0x80]), you have to prepend
-      a 0 byte: [0x00 0x80]. Otherwise it ([0x80]) will be decoded as -128. *)
+      a 0 byte: [0x00 0x80]. Otherwise it ([0x80]) will be decoded as -128. See
+      {!unsigned_integer} for automated two's complement transformations. *)
 
   val bit_string : bool array t
   (** [bit_string] is ASN.1 [BIT STRING]. *)
@@ -331,6 +332,10 @@ module S : sig
 
   val int : int t
   (** [int] is ASN.1 [INTEGER], projected into an OCaml [int]. *)
+
+  val unsigned_integer : string t
+  (** [unsigned_integer] is ASN.1 [INTEGER], where the necessary two's
+      complement transformations are already applied. *)
 
   val bit_string_flags : (int * 'a) list -> 'a list t
   (** [bit_string_flags xs] is ASN.1 [BIT STRING], represented as a collection

--- a/src/asn.mli
+++ b/src/asn.mli
@@ -335,7 +335,9 @@ module S : sig
 
   val unsigned_integer : string t
   (** [unsigned_integer] is ASN.1 [INTEGER], where the necessary two's
-      complement transformations are already applied. *)
+      complement transformations are already applied. That is, it represents
+      unsigned integers encoded as ASN.1 (signed) [INTEGER]s. Negative ASN.1
+      [INTEGER]s are rejected with a parse error. *)
 
   val bit_string_flags : (int * 'a) list -> 'a list t
   (** [bit_string_flags xs] is ASN.1 [BIT STRING], represented as a collection

--- a/src/asn_combinators.ml
+++ b/src/asn_combinators.ml
@@ -139,6 +139,40 @@ let int =
   in
   map f g integer
 
+let unsigned_integer =
+  let f str =
+    let l = String.length str in
+    if l > 0 then
+      let fst = string_get_uint8 str 0 in
+      if fst > 0x7F then
+        parse_error "unsigned integer < 0"
+      else if fst = 0x00 then
+        String.sub str 1 (l - 1)
+      else
+        str
+    else
+      str
+  and g str =
+    let l = String.length str in
+    let rec strip0 off =
+      if l - off >= 2 &&
+         string_get_uint8 str off = 0x00 &&
+         string_get_uint8 str (off + 1) < 0x80
+      then
+        strip0 (off + 1)
+      else if off = 0 then
+        str
+      else
+        String.sub str off (l - off)
+    in
+    let str' = strip0 0 in
+    if String.length str' = 0 || string_get_uint8 str' 0 > 0x7F then
+      "\x00" ^ str'
+    else
+      str'
+  in
+  map f g integer
+
 let enumerated f g = map f g @@ implicit ~cls:`Universal 0x0a int
 
 let bit_string = Prim.Bits.(map to_array of_array (Prim Bits))

--- a/src/asn_combinators.ml
+++ b/src/asn_combinators.ml
@@ -137,7 +137,16 @@ let int =
       Bytes.set_int64_be b 0 i64;
       Bytes.unsafe_to_string b
   in
-  map f g integer
+  let random () =
+    let rec go () =
+      let buf = Prim.Integer.random ~size:(Sys.word_size / 8) () in
+      (* OCaml integer are only 31 / 63 bit *)
+      try f buf with
+      | Parse_error _ -> go ()
+    in
+    go ()
+  in
+  map ~random f g integer
 
 let unsigned_integer =
   let f str =
@@ -171,7 +180,15 @@ let unsigned_integer =
     else
       str'
   in
-  map f g integer
+  let random () =
+    let rec go () =
+      let buf = Prim.Integer.random () in
+      try f buf with
+      | Parse_error _ -> go ()
+    in
+    go ()
+  in
+  map ~random f g integer
 
 let enumerated f g = map f g @@ implicit ~cls:`Universal 0x0a int
 

--- a/src/asn_prim.ml
+++ b/src/asn_prim.ml
@@ -108,18 +108,10 @@ module Integer : Prim_s with type t = string = struct
       match String.length buf with
       | 0 -> one ()
       | 1 -> buf
-      | x ->
-        if x <= Sys.word_size / 8 then
-          match string_get_uint16_be buf 0 land 0xff80 with
-          | 0x0000 | 0xff80 -> one ()
-          | _ ->
-            (* OCaml integer are only 31 / 63 bit *)
-            if string_get_uint8 buf 0 > 0x3f && Sys.word_size / 8 = x then
-              one ()
-            else
-              buf
-        else
-          one ()
+      | _ ->
+        match string_get_uint16_be buf 0 land 0xff80 with
+        | 0x0000 | 0xff80 -> one ()
+        | _ -> buf
     in
     one ()
 

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -73,15 +73,7 @@ let inverts1 ?(iters = 1000) name enc cases =
     let codec = Asn.codec enc asn and t = dec alc in
     let f () =
       for _ = 1 to iters do
-        let rec rnd () =
-          (* Asn.random is specified on the core types - and the Int carefully
-             generates values that are 63 (31) bit values. Now,
-             unsigned_integer raises when decoding negative numbers. We catch
-             and regenerate here. *)
-          try Asn.random asn with
-          | _ when name = "unsigned_integer" -> rnd ()
-        in
-        let x = rnd () in
+        let x = Asn.random asn in
         Alcotest.check t "invert" (Ok (x, ""))
           (Asn.decode codec (Asn.encode codec x))
       done in


### PR DESCRIPTION
This embeds the code to strip superfluous leading 0s, adds a leading 0 if required - and the decoding side ensures that the value is an unsigned integer, and strips of the potentially leading 0.

see https://github.com/mirleft/ocaml-x509/issues/168 https://github.com/mirleft/ocaml-x509/pull/167/commits/93d267401b377a9b7f814eae397c37d35bd500f5 https://github.com/mirleft/ocaml-x509/pull/167/commits/bcb9f135c5f929d47082152ce5119da7c9182388#diff-c5ef94a5fb6c796edc65f18a442756732566a4729ad4ab5ec8489e6481806ea1 for the motivation.